### PR TITLE
Prevent asset digest while web components are being built

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,13 +24,14 @@ class CacheDigest {
   // Executed when each compilation is finished.
   // Examples: Hot-reload (send a websocket push).
   onCompile(files, publicFiles) {
-    if (this.env == "production") {
-      this.renameFiles(files, false);
-      this.renameFiles(publicFiles, true);
-      this.renameFiles(this.files, true);
+    if (!global.buildingWebComponents) {
+      if (this.env == "production") {
+        this.renameFiles(files, false);
+        this.renameFiles(publicFiles, true);
+        this.renameFiles(this.files, true);
+      }
+      this.convertAssetUrl(files, publicFiles);
     }
-    this.convertAssetUrl(files, publicFiles);
-
   }
 
   renameFiles(files, removeFiles) {
@@ -43,7 +44,6 @@ class CacheDigest {
       } else {
         file.path = newFileName;
       }
-      fs.ensureDirSync(targetDir);
       fs.copySync(path, newFileName);
       if (removeFiles) {
         fs.removeSync(path);

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ class CacheDigest {
   // Executed when each compilation is finished.
   // Examples: Hot-reload (send a websocket push).
   onCompile(files, publicFiles) {
-    if (!global.buildingWebComponents) {
+    if (!global.processingPrecompile) {
       if (this.env == "production") {
         this.renameFiles(files, false);
         this.renameFiles(publicFiles, true);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-digest-brunch",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Adds digest support to brunch.",
   "author": "Peter Arentsen",
   "homepage": "https://github.com/nulian/cache-digest-brunch",


### PR DESCRIPTION
My previous work didn't fix anything. The problem was that the cache digest was trying to digest the file before it was even created.

The `global.buildingWebComponents` flag is toggled on and off in the onCompile callback of the brunch-config.js of Betty.